### PR TITLE
take unary union across all fires

### DIFF
--- a/scripts/projects.py
+++ b/scripts/projects.py
@@ -169,7 +169,8 @@ def get_project_fire_stats(fires, opr_id, start_dt, termination_dt):
 
     project_fires = geopandas.sjoin(eligible_fires, geom.to_crs(fires.crs))
     intersect_fires = geopandas.clip(project_fires, geom.to_crs(fires.crs))
-    return (len(intersect_fires), sum(intersect_fires.geometry.area) / m2_to_acre)
+    burned_acres = intersect_fires.unary_union.area / m2_to_acre # each acre can only burn once
+    return (len(intersect_fires), burned_acres)
 
 
 @click.command()


### PR DESCRIPTION
unary union ensures we only count each acre one time. this might not be the proper behavior when projects are much older, but for now this ensures conservativeness of burned area estimates